### PR TITLE
Fix casing of 'Popcorn' to 'PopCorn' in Core CMakeLists

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(Compat)
 add_subdirectory(Inferno)
-add_subdirectory(Popcorn)
+add_subdirectory(PopCorn)
 add_subdirectory(Stargate)
 add_subdirectory(SystemControl)
 add_subdirectory(VSHControl)


### PR DESCRIPTION
Missed this thanks to macOS. Very cool!